### PR TITLE
Add Missing A11Y Attributes and Improve Namespacing

### DIFF
--- a/src/jquery.a11yAccordion.js
+++ b/src/jquery.a11yAccordion.js
@@ -65,16 +65,39 @@
             // Add aria-controls and aria-labelledby
             _this.$titles.each(function(){
                 // Each title should have an ID, if one does not, generate one
-                if($(this).attr("id"))
+                // Generate a unique ID if we need to use it
+                var id = Math.floor(Math.random() * Date.now());
+                var tabId = "";
+                var panelId = "";
+                
+                if(!$(this).attr("id")){                  
+                  tabId = "a11y-acc-tab-"+id;
+                  $(this).attr("id",tabId);
+                  // Add a labelled by to the panel this title controls
+                  // if there is no ID there
+                  if(!$(this).next().attr("id")){
+                    panelId = "a11y-acc-panel-"+id;
+                    $(this).next().attr("id",panelId);
+                  }
+                  else{
+                    panelId = $(this).next().attr("id");
+                  }
+                }
+                else{
+                  tabId = $(this).attr("id");
+                  panelId = $(this).next().attr("id") ? $(this).next().attr("id") : "a11y-acc-panel-"+id;
+                }
+                $(this).attr("aria-controls",panelId);
+                $(this).next().attr("aria-labelledby",tabId);
             });
 
             // Hides and prevents tabbing through all DOM elements in a non-selected panel
             // Also sets aria-expanded="false" by default on $titles.
             // Allow elements to be expanded by default
-            _this.$panels.each(function() {
-                if(!$(this).hasClass('accordion-visible')){
-                  _this.hide($(this));  
-                }
+            _this.$panels.each(function() {  
+              if(!$(this).hasClass('accordion-visible')){
+                  _this.hide($(this));
+              }
             });
         },
 

--- a/src/jquery.a11yAccordion.js
+++ b/src/jquery.a11yAccordion.js
@@ -25,6 +25,9 @@
             // These are all "dt" elements on the page in an accordion
             this.$allTitles = $(".js-accordion dt");
 
+            // The accordion itsself
+            this.$accordion = $(this.element);
+
             // These are only the "dt" elements in the element
             this.$titles = $("dt", this.element);
 
@@ -46,15 +49,32 @@
 
             var _this = this;
 
+            _this.$accordion.
+                attr("role","tablist").
+                attr("aria-multiselectable","true");
+
             _this.$titles.
                 attr("aria-selected", "false").
                 not(":first").
-                attr("tabindex", "-1");
+                attr("tabindex", "-1").
+                attr("role","tab");
+
+            _this.$panels.
+                attr("role","tabpanel");
+
+            // Add aria-controls and aria-labelledby
+            _this.$titles.each(function(){
+                // Each title should have an ID, if one does not, generate one
+                if($(this).attr("id"))
+            });
 
             // Hides and prevents tabbing through all DOM elements in a non-selected panel
             // Also sets aria-expanded="false" by default on $titles.
+            // Allow elements to be expanded by default
             _this.$panels.each(function() {
-                _this.hide($(this));
+                if(!$(this).hasClass('accordion-visible')){
+                  _this.hide($(this));  
+                }
             });
         },
 

--- a/src/jquery.a11yAccordion.js
+++ b/src/jquery.a11yAccordion.js
@@ -144,7 +144,7 @@
             // Removes "hide" class and sets appropriate aria/tabindex attr on title, panel,
             // and all panel children.
             $panel.
-                removeClass("hide").
+                removeClass("a11y-acc-hide").
                 attr("aria-hidden", "false").
                 find("*").each(function() {
                     $(this).attr("tabindex", "0");
@@ -158,7 +158,7 @@
             // Adds "hide" class and sets appropriate aria/tabindex attr on title, panel,
             // and all panel children.
             $panel.
-                addClass("hide").
+                addClass("a11y-acc-hide").
                 attr("aria-hidden", "true").
                 find("*").each(function() {
                     $(this).attr("tabindex", "-1");
@@ -171,7 +171,7 @@
         toggle: function($title) {
             var $panel = $title.next();
 
-            if ( $panel.hasClass("hide") ) {
+            if ( $panel.hasClass("a11y-acc-hide") ) {
                 this.show($panel);
             } else {
                 this.hide($panel);

--- a/src/styles.css
+++ b/src/styles.css
@@ -32,6 +32,6 @@
   margin: 0
 }
 
-.accordion .hide {
+.accordion .a11y-acc-hide {
   max-height: 0;
 }


### PR DESCRIPTION
First off, thanks! This is awesome. I've made a couple of improvements to this plugin:

- The .hide class being used conflicts with many other CSS libraries (and custom CSS work), so I added a namespace here to avoid conflicts
- Added the ability to have a tab expanded by default based on the existence of a class name
- Added some missing aria labels by dynamically generating an element ID if one doesnt exist. 
  - aria-labeledby
  - aria-controls

Let me know if you want anything to be cleaned up, or if something is wrong! Thanks again for your initial work.

~ Cooper