### PR TITLE
Added Support for Accordion Inception

### DIFF
--- a/src/jquery.a11yAccordion.js
+++ b/src/jquery.a11yAccordion.js
@@ -105,8 +105,9 @@
             var _this = this;
 
             _this.$titles.
-                on("click", function() {
+                on("click", function(e) {
                     _this.toggle( $(this) );
+                    e.stopPropogation();
             }).
                 on("selectstart", function(e) {
                     e.preventDefault();


### PR DESCRIPTION
Previously, if you put an accordion inside of another accordion, the inner accordion would not open due to event bubbling. As such, I just stopped propogation of the event to keep it at the appropriate level and now it worksgit status